### PR TITLE
functie itemsJSON() aangepast, templates in step13 aangevuld

### DIFF
--- a/step10/make.js
+++ b/step10/make.js
@@ -135,7 +135,7 @@ function collection(t, collectionId) {
 //-------------------------------------------------------------------------------------
 
 function itemsJSON(collectionId, geojson) {
-    return JSON.stringify(geojson);
+    return JSON.parse(JSON.stringify(geojson));
 }
 
 function itemsHTML(collectionId, geojson) {

--- a/step11/make.js
+++ b/step11/make.js
@@ -135,7 +135,7 @@ function collection(t, collectionId) {
 //-------------------------------------------------------------------------------------
 
 function itemsJSON(collectionId, geojson) {
-    return JSON.stringify(geojson);
+    return JSON.parse(JSON.stringify(geojson));
 }
 
 function itemsHTML(collectionId, geojson) {

--- a/step12/make.js
+++ b/step12/make.js
@@ -135,7 +135,7 @@ function collection(t, collectionId) {
 //-------------------------------------------------------------------------------------
 
 function itemsJSON(collectionId, geojson) {
-    return JSON.stringify(geojson);
+    return JSON.parse(JSON.stringify(geojson));
 }
 
 function itemsHTML(collectionId, geojson) {

--- a/step13/make.js
+++ b/step13/make.js
@@ -135,7 +135,7 @@ function collection(t, collectionId) {
 //-------------------------------------------------------------------------------------
 
 function itemsJSON(collectionId, geojson) {
-    return JSON.stringify(geojson);
+    return JSON.parse(JSON.stringify(geojson));
 }
 
 function itemsHTML(collectionId, geojson) {

--- a/step13/templates/collection.template
+++ b/step13/templates/collection.template
@@ -2,9 +2,9 @@
 <html>
 <body>
 
-<h1>Metadata about the feature collections</h1>
+<h1>Metadata about the feature collection</h1>
 
-<h2>Collections.</h2>
+<h2>Collection</h2>
 <h3>{{ collection.title }} ({{ collection.title }})</h3>
 <p>{{ collection.title }}</p>
 

--- a/step13/templates/collections.template
+++ b/step13/templates/collections.template
@@ -2,6 +2,7 @@
 <html>
 <body>
 
+  <h1>Metadata about the feature collections</h1>
     <h2>Collections in this service</h2>
     <table class="striped">
       <thead>
@@ -27,6 +28,17 @@
 
       </tbody>
     </table>
+    
+    <h2>Links</h2>
+
+    <p>
+        self = 
+    <a href="{{ collection.url }}">Metadata about the feature collections</a>
+    (application/json)
+    </p>
+
+    <h2>JSON output</h2>
+    <p>Get raw <a href="{{ collection.url }}?f=json">JSON</a></p>
 
 </body>
 </html>

--- a/step13/templates/items.template
+++ b/step13/templates/items.template
@@ -36,6 +36,11 @@
 
 </script>
 <h2>JSON Output</h2>
+
+<h3>Raw JSON</h3>
+<p>Get raw <a href="{{ collection.url }}collections/{{ collection.title }}/items?f=json">JSON</a></p>
+
+<h3>JSON content</h3>
 <p>
 {{ collection.geojson }}
 </p>

--- a/step13/templates/landingPage.template
+++ b/step13/templates/landingPage.template
@@ -3,11 +3,11 @@
 <body>   
 <h1>{{ title }}</h1>
 <h2>Links</h2>
-<p>self = <a href="{{ url }}/">{{ title }}</a> (application/json)</p>
-<p>service = <a href="{{ url }}/api">the API definition (JSON)</a> (application/openapi+json;version=3.0)</p>
-<p>service = <a href="{{ url }}/api.html">the API definition (HTML)</a> (text/html)</p>
-<p>conformance = <a href="{{ url }}/conformance">WFS 3.0 conformance classes implemented by this server</a> (application/json)</p>
-<p>data = <a href="{{ url }}/collections">Metadata about the feature collections</a> (application/json)</p>
-<p>Get raw <a href="{{ url }}/?f=json">JSON</a></p>
+<p>self = <a href="{{ url }}">{{ title }}</a> (application/json)</p>
+<p>service = <a href="{{ url }}api">the API definition (JSON)</a> (application/openapi+json;version=3.0)</p>
+<p>service = <a href="{{ url }}api.html">the API definition (HTML)</a> (text/html)</p>
+<p>conformance = <a href="{{ url }}conformance">WFS 3.0 conformance classes implemented by this server</a> (application/json)</p>
+<p>data = <a href="{{ url }}collections">Metadata about the feature collections</a> (application/json)</p>
+<p>Get raw <a href="{{ url }}?f=json">JSON</a></p>
 </body>
 </html>


### PR DESCRIPTION
De functie itemsJSON() gaf een escaped versie van de GeoJSON in de JSON versie.  Door deze aanpassing is dat opgelost.  

De templates werden aangevuld met links naar de JSON versies.